### PR TITLE
Fix taxsim_cols() function

### DIFF
--- a/R/utils_clean_data.R
+++ b/R/utils_clean_data.R
@@ -68,33 +68,15 @@ taxsim_cols <- function() {
 
   # NOTE: You need to change replace_missing() and check_required_cols() if you change this function.
 
-  c(
-    "taxsimid", "year", "mstat", # required
-    "nonprop",
-    "state",
-    "page",
-    "mortgage",
-    "otheritem",
-    "pwages",
-    "psemp",
-    "proptax",
-    "rentpaid",
-    "childcare",
-    "transfers",
-    "otherprop",
-    "ltcg",
-    "stcg",
-    "dividends",
-    "intrec",
-    "pui",
-    "gssi",
-    "pensions",
-    "sage",
-    "depx",
-    "age1",
-    "age2",
-    "age3"
-  )
+c(
+  'taxsimid', 'year', 'mstat', # required
+  'state', 'page', 'sage',
+  'depx', 'age1', 'age2', 'age3', # dependents
+  'pwages', 'swages', 'psemp', 'ssemp', 'dividends', 'intrec', 'stcg', 'ltcg', 'otherprop', 'nonprop',
+  'pensions', 'gssi', 'pui', 'sui', 'transfers', 'rentpaid', 'proptax', 'otheritem',
+  'childcare', 'mortgage', 'scorp', 'pbusinc', 'pprofinc', 'sbusinc', 'sprofinc',
+  'mtr', 'idtl'
+)
 
 }
 

--- a/R/utils_clean_data.R
+++ b/R/utils_clean_data.R
@@ -69,13 +69,31 @@ taxsim_cols <- function() {
   # NOTE: You need to change replace_missing() and check_required_cols() if you change this function.
 
   c(
-    'taxsimid', 'year', 'mstat', # required
-    'state', 'page', 'sage',
-    'depx', 'age1', 'age2', 'age3', # dependents
-    'pwages', 'swages', 'dividends', 'intrec', 'stcg', 'ltcg', 'otherprop', 'nonprop',
-    'pensions', 'gssi', 'ui', 'transfers', 'rentpaid', 'proptax', 'otheritem',
-    'childcare', 'mortgage', 'scorp', 'pbusinc', 'pprofinc', 'sbusinc', 'sprofinc',
-    'mtr', 'idtl'
+    "taxsimid", "year", "mstat", # required
+    "nonprop",
+    "state",
+    "page",
+    "mortgage",
+    "otheritem",
+    "pwages",
+    "psemp",
+    "proptax",
+    "rentpaid",
+    "childcare",
+    "transfers",
+    "otherprop",
+    "ltcg",
+    "stcg",
+    "dividends",
+    "intrec",
+    "pui",
+    "gssi",
+    "pensions",
+    "sage",
+    "depx",
+    "age1",
+    "age2",
+    "age3"
   )
 
 }

--- a/R/utils_clean_data.R
+++ b/R/utils_clean_data.R
@@ -68,15 +68,15 @@ taxsim_cols <- function() {
 
   # NOTE: You need to change replace_missing() and check_required_cols() if you change this function.
 
-c(
-  'taxsimid', 'year', 'mstat', # required
-  'state', 'page', 'sage',
-  'depx', 'age1', 'age2', 'age3', # dependents
-  'pwages', 'swages', 'psemp', 'ssemp', 'dividends', 'intrec', 'stcg', 'ltcg', 'otherprop', 'nonprop',
-  'pensions', 'gssi', 'pui', 'sui', 'transfers', 'rentpaid', 'proptax', 'otheritem',
-  'childcare', 'mortgage', 'scorp', 'pbusinc', 'pprofinc', 'sbusinc', 'sprofinc',
-  'mtr', 'idtl'
-)
+  c(
+    'taxsimid', 'year', 'mstat', # required
+    'state', 'page', 'sage',
+    'depx', 'age1', 'age2', 'age3', # dependents
+    'pwages', 'swages', 'psemp', 'ssemp', 'dividends', 'intrec', 'stcg', 'ltcg', 'otherprop', 'nonprop',
+    'pensions', 'gssi', 'pui', 'sui', 'transfers', 'rentpaid', 'proptax', 'otheritem',
+    'childcare', 'mortgage', 'scorp', 'pbusinc', 'pprofinc', 'sbusinc', 'sprofinc',
+    'mtr', 'idtl'
+  )
 
 }
 


### PR DESCRIPTION

Adds a couple missing columns from the checker function as mentioned in #6. I think all cols are now included, but it could be worth checking to be sure. I'm not sure where to find the "complete" list of allowable input columns in v35 of TAXSIM.
