### PR TITLE
add option to use curl http interface for Taxsim

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,10 @@ Depends:
     R (>= 3.1)
 Imports: 
     datasets,
-    vroom
+    vroom,
+    httr,
+    tibble,
+    utils
 Suggests: 
     dplyr,
     ggplot2,

--- a/man/taxsim_calculate_taxes.Rd
+++ b/man/taxsim_calculate_taxes.Rd
@@ -7,7 +7,8 @@
 taxsim_calculate_taxes(
   .data,
   marginal_tax_rates = "Wages",
-  return_all_information = FALSE
+  return_all_information = FALSE,
+  interface = "ssh"
 )
 }
 \arguments{
@@ -20,6 +21,10 @@ This data set will be sent to TAXSIM. Data frame must have specified column name
 \item{return_all_information}{Boolean (TRUE or FALSE). Whether to return all information from TAXSIM (TRUE),
 or only key information (FALSE). Returning all information returns 42 columns of output, while only
 returning key information returns 9 columns. It is faster to download results with only key information.}
+
+\item{interface}{String indicating which NBER TAXSIM interface to use. Should be one of:
+- 'ssh': Uses SSH to connect to taxsimssh.nber.org. Your system must already have SSH installed.
+- 'http': Uses CURL to connect to https://taxsim.nber.org/uptest/webfile.cgi. Approximate max file size: 1000 rows.}
 }
 \value{
 The output data set contains all the information returned by \href{http://taxsim.nber.org/taxsim35/}{TAXSIM 35},

--- a/tests/testthat/test-calculate_taxes.R
+++ b/tests/testthat/test-calculate_taxes.R
@@ -79,3 +79,30 @@ test_that("All states work", {
   expect_equal(nrow(taxsim_output), 50)
 
 })
+
+test_that("All interface options return same values", {
+
+  states <- state.abb
+
+  id_nums <- seq(1, length(states))
+
+  taxsim_input <- data.frame(
+    taxsimid = id_nums,
+    mstat = 2,
+    year = 2018,
+    pwages = 50000,
+    state = states
+  )
+
+  ssh_results <- taxsim_calculate_taxes(taxsim_input,
+                                        return_all_information = T,
+                                        interface = 'ssh')
+
+  http_results <- taxsim_calculate_taxes(taxsim_input,
+                                         return_all_information = T,
+                                         interface = 'http')
+
+  expect(all.equal(ssh_results, http_results),
+         failure_message = "HTTP results do not match SSH results.")
+})
+


### PR DESCRIPTION
As discussed, I added the `curl` option. I also created a test to ensure the results are the same. 

A few things worth discussing and possibly changing: 

1. `utils` added to imports because I needed to use `read.table`
2. `tibble` added to imports because `vroom` returns a tibble and I wanted the outputs of the `ssh` and `http` options to have the same class. 
3. I set the `ssh` interface as the default, but maybe no-default is more future-proof. Alternatively, performance benchmarks might be a good way to choose which to have as default. A third option: separate functions or methods for each interface option (e.g. `calculate_taxes_ssh` and `calculate_taxes_http`). FWIW, I plan to submit a PR soon for a third interface option that uses the `.wasm` and `.js` files as discussed over  tmm1/taxsim.js#1, so it's worth thinking about what the selection option should look like with additional interfaces. 

Happy to make revisions - just let me know what you think! 