### PR TITLE
Fix bug in `convert_na`

### DIFF
--- a/R/utils_clean_data.R
+++ b/R/utils_clean_data.R
@@ -170,7 +170,7 @@ convert_na <- function(.data, cols_to_convert) {
   if (is.character(.data[['state']])) {
     .data[['state']][is.na(.data[['state']])] <- 'No State'
   } else if (is.numeric(.data[['state']])) {
-    .data[['state']][is.na(.data[['state']])] <- 'No State'
+    .data[['state']][is.na(.data[['state']])] <- 0
   }
 
   .data[cols_to_convert][is.na(.data[cols_to_convert])] <- 0


### PR DESCRIPTION
Existing code converts numeric `state` columns to `character` and generates incorrect errors. I think changing 'No State' to 0 fixes this, but haven't tested. 

Here's an example of the error: 
```r
> taxsim_df %>% 
+   rowid_to_column("taxsimid") %>% 
+   head(1) %>%
+   glimpse() %>% 
+   usincometaxes::taxsim_calculate_taxes(interface = "ssh")
Rows: 1
Columns: 20
$ taxsimid  <int> 1
$ w2pct     <fct> 0
$ overhead  <fct> 0.3
$ rate      <fct> 60
$ psemp     <dbl> 64475.84
$ salary    <fct> 75000
$ pwages    <dbl> 0
$ nonprop   <dbl> 0
$ otheritem <dbl> 11000
$ mstat     <dbl> 1
$ year      <dbl> 2022
$ state     <dbl> 6
$ page      <dbl> 0
$ dividends <dbl> 1000
$ intrec    <dbl> 0
$ stcg      <dbl> 500
$ ltcg      <dbl> 500
$ otherprop <dbl> 0
$ proptax   <dbl> 0
$ mortgage  <dbl> 10000
Error: One of your state names is unrecognizable. Names should either be the full name, two letter abbreviation, or SOI code.
```